### PR TITLE
Enable Dutch UI and bilingual responses

### DIFF
--- a/src/components/LanguageSelector.js
+++ b/src/components/LanguageSelector.js
@@ -3,6 +3,7 @@ import './LanguageSelector.css';
 
 const languages = [
   { code: 'en', name: 'English' },
+  { code: 'nl', name: 'Dutch' },
   { code: 'ar', name: 'Arabic العربية' },
   { code: 'tr', name: 'Turkish' },
   { code: 'ku', name: 'Kurdish کوردی' },

--- a/src/contexts/LanguageContext.js
+++ b/src/contexts/LanguageContext.js
@@ -15,6 +15,18 @@ export const translations = {
     detect: 'Detect Language',
     detecting: 'Detecting...'
   },
+  nl: {
+    appTitle: 'AI Taal Leer Assistent',
+    typeMessage: 'Typ je bericht...',
+    send: 'Verstuur',
+    thinking: 'Denken...',
+    error: 'Kon geen reactie van AI krijgen',
+    detectLanguageTitle: 'Welkom bij AI Taal Leren',
+    detectLanguageDescription: 'Voer een zin van minstens 5 woorden in je moedertaal in zodat we je voorkeurstaal kunnen detecteren.',
+    enterWord: 'Voer een woord in...',
+    detect: 'Detecteer Taal',
+    detecting: 'Detecteren...'
+  },
   ar: {
     appTitle: 'مساعد تعلم اللغات بالذكاء الاصطناعي',
     typeMessage: 'اكتب رسالتك...',

--- a/src/routes/ai.js
+++ b/src/routes/ai.js
@@ -126,6 +126,7 @@ async function routes(fastify, options) {
       // Validate if it's a supported language
       const supportedLanguages = [
         'en', // English
+        'nl', // Dutch
         'ar', // Arabic
         'tr', // Turkish
         'ku', // Kurdish (Kurmanji)
@@ -184,7 +185,12 @@ async function routes(fastify, options) {
       const { message, model = 'llama3', language = 'en' } = request.body;
       
       // Add language context to the prompt
-      const languagePrompt = `Please respond in ${language}. Here is the user's message: ${message}`;
+      let languagePrompt;
+      if (language === 'nl') {
+        languagePrompt = `Please respond in Dutch. Here is the user's message: ${message}`;
+      } else {
+        languagePrompt = `Please answer first in ${language}, then provide a Dutch translation. Here is the user's message: ${message}`;
+      }
       
       const response = await axios.post('http://localhost:11434/api/generate', {
         model: model,


### PR DESCRIPTION
## Summary
- support `nl` (Dutch) in language detection and UI translations
- show Dutch in language selector
- respond in both Dutch and the user's language

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68497bbd853c832a814665de790a1593