### PR TITLE
Fix navigation loop after language detection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import AIChat from "./components/AIChat";
 import LanguageDetection from "./components/LanguageDetection";
 import NameInputPage from './components/NameInputPage';
@@ -14,13 +14,14 @@ import './App.css';
 function AppContent() {
   const { t, isLanguageDetected, handleLanguageDetected } = useLanguage();
   const navigate = useNavigate();
+  const location = useLocation();
 
-  // Redirect to name_input if language is detected initially
+  // Redirect from root path to name input once language is detected
   React.useEffect(() => {
-    if (isLanguageDetected) {
+    if (isLanguageDetected && location.pathname === '/') {
       navigate('/name-input');
     }
-  }, [isLanguageDetected, navigate]);
+  }, [isLanguageDetected, navigate, location.pathname]);
 
   if (!isLanguageDetected) {
     return <LanguageDetection onLanguageDetected={handleLanguageDetected} />;


### PR DESCRIPTION
## Summary
- ensure redirect to `/name-input` only occurs when landing on root route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851a003a580832a97e1c1addf78ca7e