### PR TITLE
Improve card sizing and add AI Chat nav item

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import AIChat from "./components/AIChat";
 import LanguageDetection from "./components/LanguageDetection";
 import NameInputPage from './components/NameInputPage';
@@ -14,13 +14,14 @@ import './App.css';
 function AppContent() {
   const { t, isLanguageDetected, handleLanguageDetected } = useLanguage();
   const navigate = useNavigate();
+  const location = useLocation();
 
-  // Redirect to name_input if language is detected initially
+  // Redirect from root path to name input once language is detected
   React.useEffect(() => {
-    if (isLanguageDetected) {
+    if (isLanguageDetected && location.pathname === '/') {
       navigate('/name-input');
     }
-  }, [isLanguageDetected, navigate]);
+  }, [isLanguageDetected, navigate, location.pathname]);
 
   if (!isLanguageDetected) {
     return <LanguageDetection onLanguageDetected={handleLanguageDetected} />;

--- a/src/Sentences.css
+++ b/src/Sentences.css
@@ -86,8 +86,8 @@ a {
 }
 
 .card {
-    width: 12rem;
-    height: 12rem;
+    width: 7rem;
+    height: 7rem;
     display: flex;
     align-items: center;
     justify-content: space-evenly;
@@ -131,8 +131,8 @@ a {
 }
 
 img {
-    width: 45px;
-    height: 45px;
+    width: 30px;
+    height: 30px;
 }
 
 /* Top header: title + language selector */

--- a/src/Words.css
+++ b/src/Words.css
@@ -87,8 +87,8 @@ a {
 }
 
 .card {
-    width: 12rem;
-    height: 12rem;
+    width: 7rem;
+    height: 7rem;
     display: flex;
     align-items: center;
     justify-content: space-evenly;
@@ -132,8 +132,8 @@ a {
 }
 
 img {
-    width: 45px;
-    height: 45px;
+    width: 30px;
+    height: 30px;
 }
 
 /* Top header: title + language selector */

--- a/src/choose_game.css
+++ b/src/choose_game.css
@@ -232,7 +232,20 @@ background-color: #FFF8E4;
     justify-content: center;
 }
 
-.nav-words-outer, .nav-words-outer-1, .nav-words-outer-2, .nav-words-outer-3, .nav-words-outer-4 {
+.nav-words-5{
+background-color: #FFE5E5;
+    border-radius: 12px;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    color: #FF3B30;
+    font-family: 'Baloo', sans-serif;
+}
+
+.nav-words-outer, .nav-words-outer-1, .nav-words-outer-2, .nav-words-outer-3, .nav-words-outer-4, .nav-words-outer-5 {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/AIChat.css
+++ b/src/components/AIChat.css
@@ -90,4 +90,17 @@
 
 .chat-button:hover:not(:disabled) {
   background-color: #1976d2;
-} 
+}
+
+/* Bottom navigation highlight */
+.nav-words-5 {
+  border: 2px solid #FF3B30;
+}
+
+.nav-words-outer-5 p {
+  font-family: inter;
+  font-size: 14px;
+  font-weight: 100;
+  color: #FF3B30;
+  margin-top: 8px;
+}

--- a/src/components/AIChat.js
+++ b/src/components/AIChat.js
@@ -3,6 +3,7 @@ import { aiService } from '../services/aiService';
 import { useLanguage } from '../contexts/LanguageContext';
 import { fetchTranslation } from './TranslationService';
 import './AIChat.css';
+import BottomNav from './BottomNav';
 
 const AIChat = () => {
   const [messages, setMessages] = useState([]);
@@ -73,6 +74,7 @@ const AIChat = () => {
   };
 
   return (
+    <>
     <div className="chat-container">
       <div className="selectors-container">
         <select
@@ -128,6 +130,8 @@ const AIChat = () => {
         </button>
       </form>
     </div>
+    <BottomNav />
+    </>
   );
 };
 

--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import '../navigation.css';
+
+const BottomNav = () => {
+  const location = useLocation();
+  const { pathname } = location;
+
+  return (
+    <nav>
+      <div className="nav_container">
+        <Link to="/words" className={`nav-words-outer ${pathname.startsWith('/words') ? 'nav-words-outer-1' : ''}`}>
+          <div className="nav-words-1">
+            <img src="/images/Words_Icon.svg" alt="Words" />
+          </div>
+          <p>Words</p>
+        </Link>
+        <Link to="/pronunciation" className={`nav-words-outer ${pathname.startsWith('/pronunciation') ? 'nav-words-outer-2' : ''}`}>
+          <div className="nav-words-2">
+            <img src="/images/Pronunciation_Icon.svg" alt="Pronunciation" />
+          </div>
+          <p>Pronunciation</p>
+        </Link>
+        <Link to="/sentences" className={`nav-words-outer ${pathname.startsWith('/sentences') ? 'nav-words-outer-3' : ''}`}>
+          <div className="nav-words-3">
+            <img src="/images/Sentences_Icon.svg" alt="Sentences" />
+          </div>
+          <p>Sentences</p>
+        </Link>
+        <Link to="/games" className={`nav-words-outer ${pathname.startsWith('/games') ? 'nav-words-outer-4' : ''}`}>
+          <div className="nav-words-4">
+            <img src="/images/Games_Icon.svg" alt="Games" />
+          </div>
+          <p>Games</p>
+        </Link>
+        <Link to="/ai-chat" className={`nav-words-outer ${pathname.startsWith('/ai-chat') ? 'nav-words-outer-5' : ''}`}>
+          <div className="nav-words-5">AI</div>
+          <p>AI Chat</p>
+        </Link>
+      </div>
+    </nav>
+  );
+};
+
+export default BottomNav;

--- a/src/components/GamesPage.js
+++ b/src/components/GamesPage.js
@@ -1,18 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import BottomNav from './BottomNav';
 import '../choose_game.css';
 import '../navigation.css'; // Assuming navigation.css is needed for the navbar
 
 const GamesPage = () => {
   return (
     <div>
-      <nav className="navbar">
-        <Link to="/words">Words</Link>
-        <Link to="/pronunciation">Pronunciation</Link>
-        <Link to="/sentences">Sentences</Link>
-        <Link to="/games">Games</Link>
-        <Link to="/ai-chat">AI Chat</Link>
-      </nav>
 
       <div className="top-header">
         <div className="categorie/img"></div>
@@ -43,6 +37,7 @@ const GamesPage = () => {
           <h3 className="game-label">Memory</h3>
         </div>
       </div>
+      <BottomNav />
     </div>
   );
 };

--- a/src/components/PronunciationPage.js
+++ b/src/components/PronunciationPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import BottomNav from './BottomNav';
 import '../style.css';
 import '../pronunciation.css';
 import '../navigation.css';
@@ -7,13 +8,6 @@ import '../navigation.css';
 const PronunciationPage = () => {
   return (
     <div>
-      <nav className="navbar">
-        <Link to="/words">Words</Link>
-        <Link to="/pronunciation">Pronunciation</Link>
-        <Link to="/sentences">Sentences</Link>
-        <Link to="/games">Games</Link>
-        <Link to="/ai-chat">AI Chat</Link>
-      </nav>
 
       <div className="top-header">
         <div className="categorie/img"></div>
@@ -74,6 +68,7 @@ const PronunciationPage = () => {
           </Link>
         </div>
       </div>
+      <BottomNav />
     </div>
   );
 };

--- a/src/components/SentencesPage.js
+++ b/src/components/SentencesPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import BottomNav from './BottomNav';
 import '../style.css';
 import '../Sentences.css';
 import '../navigation.css';
@@ -7,13 +8,6 @@ import '../navigation.css';
 const SentencesPage = () => {
   return (
     <div>
-      <nav className="navbar">
-        <Link to="/words">Words</Link>
-        <Link to="/pronunciation">Pronunciation</Link>
-        <Link to="/sentences">Sentences</Link>
-        <Link to="/games">Games</Link>
-        <Link to="/ai-chat">AI Chat</Link>
-      </nav>
 
       <div className="top-header">
         <div className="categorie/img"></div>
@@ -73,6 +67,7 @@ const SentencesPage = () => {
           </Link>
         </div>
       </div>
+      <BottomNav />
     </div>
   );
 };

--- a/src/components/WordsPage.js
+++ b/src/components/WordsPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import BottomNav from './BottomNav';
 import '../style.css';
 import '../Words.css';
 import '../navigation.css';
@@ -7,13 +8,6 @@ import '../navigation.css';
 const WordsPage = () => {
   return (
     <div>
-      <nav className="navbar">
-        <Link to="/words">Words</Link>
-        <Link to="/pronunciation">Pronunciation</Link>
-        <Link to="/sentences">Sentences</Link>
-        <Link to="/games">Games</Link>
-        <Link to="/ai-chat">AI Chat</Link>
-      </nav>
 
       <div className="top-header">
         <div className="categorie/img"></div>
@@ -73,6 +67,7 @@ const WordsPage = () => {
           </Link>
         </div>
       </div>
+      <BottomNav />
     </div>
   );
 };

--- a/src/navigation.css
+++ b/src/navigation.css
@@ -42,7 +42,20 @@ background-color: #FFF8E4;
     justify-content: center;
 }
 
-.nav-words-outer, .nav-words-outer-1, .nav-words-outer-2, .nav-words-outer-3, .nav-words-outer-4 {
+.nav-words-5{
+background-color: #FFE5E5;
+    border-radius: 12px;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    color: #FF3B30;
+    font-family: 'Baloo', sans-serif;
+}
+
+.nav-words-outer, .nav-words-outer-1, .nav-words-outer-2, .nav-words-outer-3, .nav-words-outer-4, .nav-words-outer-5 {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/pronunciation.css
+++ b/src/pronunciation.css
@@ -88,8 +88,8 @@ a {
 }
 
 .card {
-    width: 12rem;
-    height: 12rem;
+    width: 7rem;
+    height: 7rem;
     display: flex;
     align-items: center;
     justify-content: space-evenly;
@@ -133,8 +133,8 @@ a {
 }
 
 img {
-    width: 45px;
-    height: 45px;
+    width: 30px;
+    height: 30px;
 }
 
 /* Top header: title + language selector */

--- a/src/snake_game.css
+++ b/src/snake_game.css
@@ -261,7 +261,20 @@ background-color: #FFF8E4;
     justify-content: center;
 }
 
-.nav-words-outer, .nav-words-outer-1, .nav-words-outer-2, .nav-words-outer-3, .nav-words-outer-4 {
+.nav-words-5{
+background-color: #FFE5E5;
+    border-radius: 12px;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    color: #FF3B30;
+    font-family: 'Baloo', sans-serif;
+}
+
+.nav-words-outer, .nav-words-outer-1, .nav-words-outer-2, .nav-words-outer-3, .nav-words-outer-4, .nav-words-outer-5 {
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## Summary
- reduce vocabulary card sizes for better mobile fit
- integrate bottom navigation into AI Chat page
- add AI Chat entry to bottom navigation bar
- highlight AI Chat tab with red styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851a003a580832a97e1c1addf78ca7e